### PR TITLE
risc-v/bl808: Add GPIO Driver

### DIFF
--- a/arch/risc-v/src/bl808/Make.defs
+++ b/arch/risc-v/src/bl808/Make.defs
@@ -27,5 +27,5 @@ HEAD_ASRC = bl808_head.S
 # Specify our C code within this directory to be included
 CHIP_CSRCS  = bl808_start.c bl808_irq_dispatch.c bl808_irq.c
 CHIP_CSRCS += bl808_timerisr.c bl808_allocateheap.c
-CHIP_CSRCS += bl808_mm_init.c bl808_pgalloc.c bl808_serial.c
+CHIP_CSRCS += bl808_gpio.c bl808_mm_init.c bl808_pgalloc.c bl808_serial.c
 CHIP_CSRCS += bl808_courier.c

--- a/arch/risc-v/src/bl808/bl808_gpio.c
+++ b/arch/risc-v/src/bl808/bl808_gpio.c
@@ -1,0 +1,143 @@
+/****************************************************************************
+ * arch/risc-v/src/bl808/bl808_gpio.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <sys/param.h>
+
+#include "riscv_internal.h"
+#include "hardware/bl808_glb.h"
+#include "bl808_gpio.h"
+#include "bl808_memorymap.h"
+
+#define BL808_NGPIOS 45
+#define GPIO_O_SHIFT 24
+#define GPIO_I_SHIFT 28
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bl808_configgpio
+ *
+ * Description:
+ *   Configure a GPIO pin based on encoded pin attributes.
+ *
+ ****************************************************************************/
+
+int bl808_configgpio(int pin, gpio_pinattr_t attr)
+{
+  uintptr_t regaddr;
+  uint32_t cfg = 0;
+
+  DEBUGASSERT(pin >= 0 && pin <= BL808_NGPIOS);
+
+  if (attr & GPIO_INPUT)
+    {
+      cfg |= GPIO_CFGCTL0_GPIO_0_IE;
+    }
+  else
+    {
+      cfg |= GPIO_CFGCTL0_GPIO_0_OE;
+    }
+
+  if (attr & GPIO_PULLUP)
+    {
+      cfg |= GPIO_CFGCTL0_GPIO_0_PU;
+    }
+
+  if (attr & GPIO_PULLDOWN)
+    {
+      cfg |= GPIO_CFGCTL0_GPIO_0_PD;
+    }
+
+  if (attr & GPIO_DRV_MASK)
+    {
+      cfg |= ((attr & GPIO_DRV_MASK) >> GPIO_DRV_SHIFT) <<
+        GPIO_CFGCTL0_GPIO_0_DRV_SHIFT;
+    }
+
+  if (attr & GPIO_SMT_EN)
+    {
+      cfg |= GPIO_CFGCTL0_GPIO_0_SMT;
+    }
+
+  if (attr & GPIO_FUNC_MASK)
+    {
+      cfg |= ((attr & GPIO_FUNC_MASK) >> GPIO_FUNC_SHIFT) <<
+        GPIO_CFGCTL0_GPIO_0_FUNC_SEL_SHIFT;
+    }
+
+  regaddr = BL808_GPIO_BASE + (pin * 4);
+  putreg32(cfg, regaddr);
+  return OK;
+}
+
+/****************************************************************************
+ * Name: bl808_gpiowrite
+ *
+ * Description:
+ *   Write one or zero to the selected GPIO pin
+ *
+ ****************************************************************************/
+
+void bl808_gpiowrite(int pin, bool value)
+{
+  uintptr_t regaddr;
+
+  DEBUGASSERT(pin >= 0 && pin <= BL808_NGPIOS);
+
+  regaddr = BL808_GPIO_BASE + (pin * 4);
+  if (value)
+    {
+      modifyreg32(regaddr, 0, (1 << GPIO_O_SHIFT));
+    }
+  else
+    {
+      modifyreg32(regaddr, (1 << GPIO_O_SHIFT), 0);
+    }
+}
+
+/****************************************************************************
+ * Name: bl808_gpioread
+ *
+ * Description:
+ *   Read one or zero from the selected GPIO pin
+ *
+ ****************************************************************************/
+
+bool bl808_gpioread(int pin)
+{
+  uintptr_t regaddr;
+  uint32_t regval;
+
+  DEBUGASSERT(pin >= 0 && pin <= BL808_NGPIOS);
+
+  regaddr = BL808_GPIO_BASE + (pin * 4);
+  regval = getreg32(regaddr);
+  return (regval & (1 << GPIO_I_SHIFT)) != 0;
+}
+

--- a/arch/risc-v/src/bl808/bl808_gpio.h
+++ b/arch/risc-v/src/bl808/bl808_gpio.h
@@ -1,0 +1,188 @@
+/****************************************************************************
+ * arch/risc-v/src/bl808/bl808_gpio.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_BL808_BL808_GPIO_H
+#define __ARCH_RISCV_SRC_BL808_BL808_GPIO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Pre-Processor Declarations
+ ****************************************************************************/
+
+/* Encoded GPIO Attributes
+ *
+ * 1111 1100 0000 0000
+ * 5432 1098 7654 3210
+ * ---- ---- ---- ----
+ * .... ..MU UDDS FFFF
+ */
+
+/* Mode:
+ *
+ * 1111 1100 0000 0000
+ * 5432 1098 7654 3210
+ * ---- ---- ---- ----
+ * .... ..M. .... ....
+ */
+
+#define GPIO_MODE_SHIFT  (9)                     /* Bit 9: Port Mode */
+#define GPIO_MODE_MASK   (1 << GPIO_MODE_SHIFT)
+#  define GPIO_INPUT     (1 << GPIO_MODE_SHIFT)  /* Input Enable */
+#  define GPIO_OUTPUT    (0 << GPIO_MODE_SHIFT)  /* Output Enable */
+
+/* Input/Output pull-ups/downs:
+ *
+ * 1111 1100 0000 0000
+ * 5432 1098 7654 3210
+ * ---- ---- ---- ----
+ * .... ...U U... ....
+ */
+
+#define GPIO_PUPD_SHIFT (7) /* Bits 7-8: Pull-up/down */
+#define GPIO_PUPD_MASK  (3 << GPIO_PUPD_SHIFT)
+#define GPIO_FLOAT      (0 << GPIO_PUPD_SHIFT) /* No pull-up, pull-down */
+#define GPIO_PULLUP     (1 << GPIO_PUPD_SHIFT) /* Pull-up */
+#define GPIO_PULLDOWN   (2 << GPIO_PUPD_SHIFT) /* Pull-down */
+
+/* Drive:
+ *
+ * 1111 1100 0000 0000
+ * 5432 1098 7654 3210
+ * ---- ---- ---- ----
+ * .... .... .DD. ....
+ */
+
+#define GPIO_DRV_SHIFT (5) /* Bits 5-6: Drive */
+#define GPIO_DRV_MASK  (3 << GPIO_DRV_SHIFT)
+#define GPIO_DRV_0     (0 << GPIO_DRV_SHIFT)
+#define GPIO_DRV_1     (1 << GPIO_DRV_SHIFT)
+#define GPIO_DRV_2     (2 << GPIO_DRV_SHIFT)
+#define GPIO_DRV_3     (3 << GPIO_DRV_SHIFT)
+
+/* Input Schmitt trigger:
+ *
+ * 1111 1100 0000 0000
+ * 5432 1098 7654 3210
+ * ---- ---- ---- ----
+ * .... .... ...S ....
+ */
+
+#define GPIO_SMT_SHIFT (4) /* Bit 4: SMT Enable */
+#define GPIO_SMT_MASK  (3 << GPIO_SMT_SHIFT)
+#define GPIO_SMT_DIS   (0 << GPIO_SMT_SHIFT)
+#define GPIO_SMT_EN    (1 << GPIO_SMT_SHIFT)
+
+/* GPIO type selection:
+ *
+ * 1111 1100 0000 0000
+ * 5432 1098 7654 3210
+ * ---- ---- ---- ----
+ * .... .... .... FFFF
+ */
+
+#define GPIO_FUNC_SHIFT  (0) /* Bits 0-3: GPIO Type */
+#define GPIO_FUNC_MASK   (15 << GPIO_FUNC_SHIFT)
+#define GPIO_FUNC_SDIO   (1  << GPIO_FUNC_SHIFT)  /* SDIO */
+#define GPIO_FUNC_FLASH  (2  << GPIO_FUNC_SHIFT)  /* Flash */
+#define GPIO_FUNC_SPI    (4  << GPIO_FUNC_SHIFT)  /* SPI */
+#define GPIO_FUNC_I2C    (6  << GPIO_FUNC_SHIFT)  /* I2C */
+#define GPIO_FUNC_UART   (7  << GPIO_FUNC_SHIFT)  /* UART */
+#define GPIO_FUNC_PWM    (8  << GPIO_FUNC_SHIFT)  /* PWM */
+#define GPIO_FUNC_EXT_PA (9  << GPIO_FUNC_SHIFT)  /* Analog */
+#define GPIO_FUNC_ANA    (10 << GPIO_FUNC_SHIFT)  /* Analog */
+#define GPIO_FUNC_SWGPIO (11 << GPIO_FUNC_SHIFT)  /* Software GPIO */
+#define GPIO_FUNC_JTAG   (14 << GPIO_FUNC_SHIFT)  /* JTAG */
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+/* Must be big enough to hold the above encodings */
+
+typedef uint16_t gpio_pinattr_t;
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bl808_configgpio
+ *
+ * Description:
+ *   Configure a GPIO pin based on encoded pin attributes.
+ *
+ ****************************************************************************/
+
+int bl808_configgpio(int pin, gpio_pinattr_t attr);
+
+/****************************************************************************
+ * Name: bl808_gpiowrite
+ *
+ * Description:
+ *   Write one or zero to the selected GPIO pin
+ *
+ ****************************************************************************/
+
+void bl808_gpiowrite(int pin, bool value);
+
+/****************************************************************************
+ * Name: bl808_gpioread
+ *
+ * Description:
+ *   Read one or zero from the selected GPIO pin
+ *
+ ****************************************************************************/
+
+bool bl808_gpioread(int pin);
+
+#ifdef __cplusplus
+}
+#endif
+#undef EXTERN
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_RISCV_SRC_BL808_BL808_GPIO_H */

--- a/arch/risc-v/src/bl808/hardware/bl808_memorymap.h
+++ b/arch/risc-v/src/bl808/hardware/bl808_memorymap.h
@@ -28,7 +28,7 @@
 /* Register Base Address ****************************************************/
 
 #define BL808_GLB_BASE     0x20000000ul
-
+#define BL808_GPIO_BASE    0x200008c4ul
 #define BL808_UART0_BASE   0x2000a000ul
 #define BL808_UART1_BASE   0x2000a100ul
 #define BL808_UART2_BASE   0x2000aa00ul


### PR DESCRIPTION
## Summary
- This PR adds the GPIO Driver for BL808 SoC. This will be used by the upcoming LED Driver for Ox64 Board.
- The BL808 GPIO Driver was derived from the NuttX Driver for BL602 GPIO

## Modified Files in arch/risc-v/src/bl808:
- `hardware/bl808_memorymap.h`: GPIO Base Address
- `Make.defs`: Added GPIO Source Files

## New Files in arch/risc-v/src/bl808:
- `bl808_gpio.c`: GPIO Functions
- `bl808_gpio.h`: GPIO Declarations

## Impact
- With this PR, NuttX for Ox64 will be able to access GPIO Pins
- This PR is needed for the upcoming LED Driver for Ox64 Board
- No impact on existing code, since the BL808 GPIO source files are not used by existing code

## Testing
We tested the BL808 Driver on Ox64 Emulator. Rust Blinky blinks the Simulated LED correctly:
- [Test Log for Ox64 Emulator](https://github.com/rushabhvg/rushabhvg.github.io/blob/master/nuttx/GPIO%20and%20LED%20Driver/0121b39efe%20build_log.txt)
- [Source Files](https://github.com/rushabhvg/nuttx/tree/gpio)
- [Rust Blinky](https://github.com/rushabhvg/nuttx-apps/blob/gpio/examples/hello_rust/hello_rust_main.rs)

```text
$ tools/configure.sh ox64:nsh
$ make
## Omitted: Build NuttX Apps and bundle into NuttX Image
$ ./temu nuttx.cfg
TinyEMU Emulator for Ox64 BL808 RISC-V SBC
NuttShell (NSH)
nsh> nx_start: CPU0: Beginning Idle Loop

nsh> uname -a
NuttX 0.0.0 0121b39efe Jun 22 2024 10:49:36 risc-v ox64

nsh> hello_rust
Hello, Rust!!
Opening /dev/userleds
Set LED 0 to 1
{"nuttxemu":{"gpio29":1}}
Waiting...
Set LED 0 to 0
{"nuttxemu":{"gpio29":0}}
```
